### PR TITLE
feat: add real active user presence count (v3.1.0)

### DIFF
--- a/bin/slackin.js
+++ b/bin/slackin.js
@@ -61,6 +61,10 @@ flags.recaptcha = {
 
 // Advanced parameters (env-only)
 flags.pageDelay = process.env.SLACKIN_PAGE_DELAY;
+flags.fetchPresence = Boolean(process.env.SLACKIN_PRESENCE);
+flags.presenceInterval = process.env.SLACKIN_PRESENCE_INTERVAL
+  ? Number(process.env.SLACKIN_PRESENCE_INTERVAL)
+  : undefined;
 flags.proxy = Boolean(process.env.SLACKIN_PROXY);
 flags.redirectFQDN = process.env.SLACKIN_HTTPS_REDIRECT;
 flags.letsencrypt = process.env.SLACKIN_LETSENCRYPT;

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,8 @@ function slackin({
   coc,
   proxy,
   pageDelay = 0,
+  fetchPresence,
+  presenceInterval,
   redirectFQDN,
   letsencrypt,
   silent,
@@ -196,6 +198,8 @@ function slackin({
     org,
     pageDelay,
     fetchChannels: Boolean(channels),
+    fetchPresence: Boolean(fetchPresence),
+    presenceInterval,
     logger: slackLog,
   });
   slack.setMaxListeners(Number.POSITIVE_INFINITY);

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -10,13 +10,15 @@ function sleep(ms) {
 }
 
 class SlackData extends EventEmitter {
-  constructor({token, interval, logger, pageDelay, fetchChannels, org: host}) {
+  constructor({token, interval, logger, pageDelay, fetchChannels, fetchPresence, presenceInterval, org: host}) {
     super();
     this.host = host;
     this.token = token;
     this.interval = interval;
     this.pageDelay = pageDelay;
     this.fetchChannels = fetchChannels;
+    this.fetchPresence = fetchPresence;
+    this.presenceInterval = presenceInterval || 86_400_000; // default 24h
     this.ready = false;
     this.org = {};
     this.users = {};
@@ -36,6 +38,9 @@ class SlackData extends EventEmitter {
 
     this.init();
     this.fetchUserCount();
+    if (this.fetchPresence) {
+      this.refreshPresence();
+    }
   }
 
   async init() {
@@ -124,9 +129,7 @@ class SlackData extends EventEmitter {
     users = users.filter(x => x.id !== 'USLACKBOT' && !x.is_bot && !x.deleted);
 
     const total = users.length;
-    // Note: Slack deprecated the presence API, so active count is no longer available
-    // Set to 0 to indicate it's not tracked
-    const active = 0;
+    const active = this.users.active || 0;
 
     if (this.users) {
       if (total !== this.users.total) {
@@ -148,6 +151,75 @@ class SlackData extends EventEmitter {
 
     setTimeout(this.fetchUserCount.bind(this), this.interval);
     return this.emit('data');
+  }
+
+  async fetchPresenceCount(users) {
+    let active = 0;
+    const batchSize = 10;
+    const batchDelay = this.pageDelay || 1200; // ~50 req/min rate limit
+
+    for (let i = 0; i < users.length; i += batchSize) {
+      const batch = users.slice(i, i + batchSize);
+      // eslint-disable-next-line no-await-in-loop
+      const results = await Promise.allSettled(batch.map(user => this.client.users.getPresence({user: user.id})));
+
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value.presence === 'active') {
+          active++;
+        }
+      }
+
+      if (i + batchSize < users.length) {
+        await sleep(batchDelay); // eslint-disable-line no-await-in-loop
+      }
+    }
+
+    return active;
+  }
+
+  async refreshPresence() {
+    // Re-fetch the current user list to get presence against
+    let users = [];
+    let cursor;
+
+    try {
+      do {
+        const response = await this.client.users.list({ // eslint-disable-line no-await-in-loop
+          limit: 800,
+          cursor,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Slack API error: ${response.error}`);
+        }
+
+        users = [...users, ...response.members];
+        cursor = response.response_metadata?.next_cursor;
+
+        if (cursor && this.pageDelay) {
+          await sleep(this.pageDelay); // eslint-disable-line no-await-in-loop
+        }
+      } while (cursor);
+    } catch (error) {
+      this.emit('error', error);
+      setTimeout(this.refreshPresence.bind(this), this.presenceInterval);
+      return;
+    }
+
+    users = users.filter(x => x.id !== 'USLACKBOT' && !x.is_bot && !x.deleted);
+
+    try {
+      const active = await this.fetchPresenceCount(users);
+      if (active !== this.users.active) {
+        this.users.active = active;
+        this.emit('change', 'active', active);
+        this.emit('data');
+      }
+    } catch (error) {
+      this.emit('error', error);
+    }
+
+    setTimeout(this.refreshPresence.bind(this), this.presenceInterval);
   }
 
   getChannelId(name) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inviterbot",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Modernized Slack invite bot for public communities",
   "repository": "hangops/inviterbot",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Replaces hardcoded `active = 0` with real data from Slack's `users.getPresence` API
- Presence fetching is opt-in via `SLACKIN_PRESENCE=true` (avoids extra API cost for those who don't need it)
- Refreshes on a separate long-interval timer (default 24h, overridable with `SLACKIN_PRESENCE_INTERVAL` in ms) so it doesn't hammer the API
- Batches presence calls 10 at a time with delays to stay within Slack's Tier 3 rate limit (~50 req/min)
- Bumps version `3.0.0` → `3.1.0`

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] Deploy with `SLACKIN_PRESENCE=true` and verify the "X users online" count appears on the page
- [ ] Deploy without `SLACKIN_PRESENCE` set and verify only total count shows (existing behavior)
- [ ] Confirm Slack bot token has `users:read` scope (required for `users.getPresence` on other users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)