### PR TITLE
fix: parse JSON-format blockdomains.txt correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,11 +89,26 @@ function slackin({
   }
 
   if (blockDomains) {
-    // convert to an hash for fast lookups
+    // convert to a hash for fast lookups
     const blockDomainsHash = {};
-    for (const d of blockDomains.split(/[,\n]/)) {
-      if (!d.startsWith('#')) {
-        blockDomainsHash[d] = true;
+    let domainList;
+
+    // Support JSON array format (e.g. blockdomains.txt) or plain comma/newline-separated text
+    const trimmed = blockDomains.trim();
+    if (trimmed.startsWith('[')) {
+      try {
+        domainList = JSON.parse(trimmed);
+      } catch {
+        domainList = trimmed.split(/[,\n]/);
+      }
+    } else {
+      domainList = trimmed.split(/[,\n]/);
+    }
+
+    for (const d of domainList) {
+      const domain = d.trim();
+      if (domain && !domain.startsWith('#')) {
+        blockDomainsHash[domain] = true;
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -44,6 +44,69 @@ describe('slackin', () => {
         .end(done);
     });
 
+    it('silently drops invite for blocked domain (JSON blocklist)', done => {
+      const opts = {
+        token: 'mytoken',
+        org: 'myorg',
+        inviteMode: 'link',
+        blockDomains: '["spam.com","disposable.net"]',
+      };
+
+      const app = slackin(opts);
+
+      request(app)
+        .post('/invite')
+        .send({email: 'attacker@spam.com'})
+        .expect('Content-Type', /json/)
+        .expect(200, {
+          msg: 'WOOT. Check your email!',
+          redirectUrl: 'https://myorg.slack.com/',
+        })
+        .end(done);
+    });
+
+    it('silently drops invite for blocked domain (plain-text blocklist)', done => {
+      const opts = {
+        token: 'mytoken',
+        org: 'myorg',
+        inviteMode: 'link',
+        blockDomains: 'spam.com\ndisposable.net',
+      };
+
+      const app = slackin(opts);
+
+      request(app)
+        .post('/invite')
+        .send({email: 'attacker@spam.com'})
+        .expect('Content-Type', /json/)
+        .expect(200, {
+          msg: 'WOOT. Check your email!',
+          redirectUrl: 'https://myorg.slack.com/',
+        })
+        .end(done);
+    });
+
+    it('allows any non-blocked email when SLACKIN_EMAILS is not set', done => {
+      const opts = {
+        token: 'mytoken',
+        org: 'myorg',
+        inviteMode: 'link',
+        blockDomains: '["spam.com"]',
+      };
+
+      const app = slackin(opts);
+
+      request(app)
+        .post('/invite')
+        .send({email: 'user@gmail.com'})
+        .expect('Content-Type', /json/)
+        .expect(303, {
+          msg: 'Sending you to Slack...',
+          redirectUrl: 'https://myorg.slack.com/',
+        })
+        .end(done);
+    });
+
     it('returns success for API mode invite', done => {
       const opts = {
         token: 'mytoken',


### PR DESCRIPTION
## Summary

- The `blockdomains.txt` file is a JSON array (`["spam.com", ...]`) but the parser was using `split(/[,\n]/)`, producing hash keys like `  "spam.com"` (with spaces and quotes) — so **no domains were ever blocked**
- Updated parsing to detect JSON arrays and use `JSON.parse()`, with a fallback to the existing comma/newline split for plain-text lists
- Added `trim()` on each entry to handle whitespace in the plain-text path

## Why this matters for the reported issue

The `@hangops.com`-only restriction comes from `SLACKIN_EMAILS` being set in the live Cloud Run service (not in `service.yaml`). The `service.yaml` already does NOT have `SLACKIN_EMAILS` set, so **redeploying from `service.yaml` will remove that restriction** and allow any email.

This PR fixes the related bug where the blocklist was silently not working — meaning spam/disposable domains were never actually blocked despite the large `blockdomains.txt` list.

## Test plan

- [x] `npm test` — all 8 tests pass
- [x] New test: blocked domain (JSON format) returns silent 200
- [x] New test: blocked domain (plain-text format) returns silent 200
- [x] New test: non-blocked email proceeds normally when `SLACKIN_EMAILS` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)